### PR TITLE
Changes how the Add To Slack process works from Slack perspective

### DIFF
--- a/xpnk-api.go
+++ b/xpnk-api.go
@@ -326,6 +326,8 @@ func SlackCreateNewGroup (c *gin.Context) {
 	c.Bind(&team_tokens) 
 	fmt.Printf("TEAM TOKENS: %+v", team_tokens)
 	fmt.Printf("TOKEN ONLY:  %+v", team_tokens.TeamToken)
+	fmt.Printf("TEST MODE: %+v", team_tokens.TestToken)
+
 	
 	token = team_tokens.TeamToken
 	bot_token = team_tokens.BotToken

--- a/xpnk-group/xpnk_createGroupFromSlack/inviteSlacker.go
+++ b/xpnk-group/xpnk_createGroupFromSlack/inviteSlacker.go
@@ -36,6 +36,7 @@ func Invite (slacker Slacker) string {
 	api.SetDebug(true)
 	
 	var invite_domain		string
+	var invite_url			string
 	
 	if test_token != "true" {
 		invite_domain		= "https://xapnik.com/"
@@ -43,7 +44,12 @@ func Invite (slacker Slacker) string {
 		invite_domain		= "http://localhost:8100/"
 	}		
 	
-	invite_url				:= invite_domain+xpnk_group+"/slack-invite/?xpnk_tkn="+xpnk_token
+	if test_token != "true" {
+		invite_url			= invite_domain+xpnk_group+"/slack-invite/?xpnk_tkn="+xpnk_token
+	} else {
+		invite_url			= invite_domain+"/slack-invite/?xpnk_tkn="+xpnk_token+"&state=invite"+"&group="+xpnk_group
+	}
+
 	
 	fmt.Printf("Invite url:   %s/n", invite_url)
 	

--- a/xpnk_disqus/json-manager/json-manager.go
+++ b/xpnk_disqus/json-manager/json-manager.go
@@ -36,7 +36,7 @@ func get_groups() []GroupID {
 	
 	//get all group ids from the GROUPS table	
 
-	_,err := dbmap.Select(&group_ids, "SELECT `Group_ID` FROM GROUPS")
+	_,err := dbmap.Select(&group_ids, "SELECT `Group_ID` FROM groups")
 	
 	if err != nil {fmt.Printf("There was an error ", err)}
 	

--- a/xpnk_disqus/xpnk_createDisqusJSON/createDisqusJSON.go
+++ b/xpnk_disqus/xpnk_createDisqusJSON/createDisqusJSON.go
@@ -70,7 +70,7 @@ func CreateDisqusJSON(group_id int) string {
 	* converting the group name into a string to use in the filename
 	******/
 	//get group name to use for the filename	
-	err := dbmap.SelectOne(&group_name, "SELECT `group_name` FROM `GROUPS` WHERE `Group_ID`=?", group_id)
+	err := dbmap.SelectOne(&group_name, "SELECT `group_name` FROM `groups` WHERE `Group_ID`=?", group_id)
 
 	if err != nil {fmt.Printf("There was an error ", err)}
 

--- a/xpnk_instagram/json-manager/json-manager.go
+++ b/xpnk_instagram/json-manager/json-manager.go
@@ -36,7 +36,7 @@ func get_groups() []GroupID {
 	
 	//get all group ids from the GROUPS table	
 
-	_,err := dbmap.Select(&group_ids, "SELECT `Group_ID` FROM GROUPS")
+	_,err := dbmap.Select(&group_ids, "SELECT `Group_ID` FROM groups")
 	
 	if err != nil {fmt.Printf("There was an error ", err)}
 	

--- a/xpnk_instagram/xpnk_createInstaJSON/createInstaJSON.go
+++ b/xpnk_instagram/xpnk_createInstaJSON/createInstaJSON.go
@@ -66,7 +66,7 @@ func CreateInstaJSON(group_id int) string {
 	* converting the group name into a string to use in the filename
 	******/
 	//get group name to use for the filename	
-	err := dbmap.SelectOne(&group_name, "SELECT `group_name` FROM `GROUPS` WHERE `Group_ID`=?", group_id)
+	err := dbmap.SelectOne(&group_name, "SELECT `group_name` FROM `groups` WHERE `Group_ID`=?", group_id)
 
 	if err != nil {fmt.Printf("There was an error ", err)}
 

--- a/xpnk_twitter/create-group-tweets-json.go
+++ b/xpnk_twitter/create-group-tweets-json.go
@@ -68,7 +68,7 @@ func Create_group_tweets_json() {
 		* converting the group name into a string to use in the filename
 		******/
 		//get group name to use for the filename	
-		err := dbmap.SelectOne(&group_name, "SELECT `group_name` FROM `GROUPS` WHERE `Group_ID`=?", this_group)
+		err := dbmap.SelectOne(&group_name, "SELECT `group_name` FROM `groups` WHERE `Group_ID`=?", this_group)
 	
 		if err != nil {fmt.Printf("There was an error ", err)}
 

--- a/xpnk_twitter/get-all-groups.go
+++ b/xpnk_twitter/get-all-groups.go
@@ -22,7 +22,7 @@ func Get_Groups () []GroupID {
 	
 	//get all group ids from the GROUPS table	
 
-	_,err := dbmap.Select(&group_ids, "SELECT `Group_ID` FROM GROUPS")
+	_,err := dbmap.Select(&group_ids, "SELECT `Group_ID` FROM groups")
 	
 	if err != nil {fmt.Printf("There was an error ", err)}
 	


### PR DESCRIPTION
Renames the incredibly dumb and inconvenient 'GROUPS' table name to 'groups' for prouction :\